### PR TITLE
fix: Update init condition for submodules

### DIFF
--- a/submodules_automation.sh
+++ b/submodules_automation.sh
@@ -4,8 +4,9 @@ git pull origin main
 # ASSUMING ALL PROJECTS HAVE BEEN ADDED AS GIT SUBMODULES
 # To include a new project into the list of added projects
 # add it's proper name into the sequence below called `projects`
-projects=("UniPath.io" "rowdybot" "react-mui-resume")
+git submodule update --init
 git submodule foreach git pull origin main
+projects=("UniPath.io" "rowdybot" "react-mui-resume")
 for i in "${projects[@]}"; do
-    rsync ./submodules/$i/docs/web_docs/* ./docs/projects/$i
+    rsync ~/UMLCloudComputing.github.io/submodules/$i/docs/web_docs/* ~/UMLCloudComputing.github.io/docs/projects/$i
 done


### PR DESCRIPTION
Quick fix to include a required init command for first time submodule instantiation (New Repo Clones).  The command is required to start performing git submodule commands.

Tested: Locally Yes