### PR TITLE
feat: update announcement bar with spring 2025 kickoff info

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -118,14 +118,14 @@ const config = {
         disableSwitch: false,
         respectPrefersColorScheme: true,
       },
-      // announcementBar: {
-      //   id: 'announcement-bar',
-      //   content:
-      //     'ADD CONTENT HERE',
-      //   backgroundColor: '#48a0ff',
-      //   textColor: '#fff',
-      //   isCloseable: false
-      // },
+      announcementBar: {
+        id: 'announcement-bar',
+        content:
+          '🚀 Spring 2025 Kick-off meeting this Thursday (1/30/2025)! See our <a href="https://umlcloudcomputing.org/docs/spring-2025/week-2">schedule</a> for more details. 🚀',
+        backgroundColor: '#48a0ff',
+        textColor: '#fff',
+        isCloseable: false
+      },
       navbar: {
         title: 'UML Cloud Computing Club',
         logo: {


### PR DESCRIPTION
## 📋 PR Info

### Description:
Updates the announcement bar with the details of our spring 2025 kickoff meeting.

### Tested
- [X ] Yes 
- [ ] No

Had an older version of the site on my local machine and tested it with that and it worked but I cannot run the most recent because I am missing the .env file. I think this should work properly with the newest version though so let me know if I missed anything.

