### PR TITLE
Refactor to allow gracefully failing if no env file provided

### DIFF
--- a/docs/schedule/2024Fall/2024Fall.md
+++ b/docs/schedule/2024Fall/2024Fall.md
@@ -8,7 +8,7 @@ ogDescription: Explore the Fall 2024 meeting schedule for the UMass Lowell Cloud
 ---
 
 :::danger
-This schedule is outdated and refers to a past semester. Please check the [latest schedule](../current-schedule) for current information.
+This schedule is outdated and refers to a past semester. Please check the [latest schedule](../docs/current-schedule) for current information.
 :::
 
 

--- a/src/components/Auth/index.js
+++ b/src/components/Auth/index.js
@@ -5,6 +5,7 @@ import React from "react";
 import { useAuth } from "react-oidc-context";
 import { Redirect, useLocation } from "@docusaurus/router";
 import ReactLoading from 'react-loading';
+import { isEnvLocalLoaded } from '../../utils/env';
 
 import {
   // AUTHENTICATED,
@@ -20,8 +21,15 @@ export function AuthCheck({ children }) {
   let from = location.pathname;
   const auth = useAuth();
 
-  const [local_logout_uri, prod_logout_uri] = process.env.OAUTH_REDIRECT_SIGN_OUT.split(",");
-  
+  // If .env.local is missing, skip all auth logic and just render children
+  if (!isEnvLocalLoaded()) {
+    return <>{children}</>;
+  }
+
+  // Defensive: Only split if OAUTH_REDIRECT_SIGN_OUT is defined
+  const signOutUris = process.env.OAUTH_REDIRECT_SIGN_OUT ? process.env.OAUTH_REDIRECT_SIGN_OUT.split(",") : ["", ""];
+  const [local_logout_uri, prod_logout_uri] = signOutUris;
+
   const signOutRedirect = () => {
     const clientId = process.env.CLIENT_ID;
     const logoutUri = process.env.ENV === "localhost"

--- a/src/config/cognito-auth-config.js
+++ b/src/config/cognito-auth-config.js
@@ -1,11 +1,15 @@
 // src/config/cognito-auth-config.js
 
+import { isEnvLocalLoaded, getEnvVar } from '../utils/env';
+
 const cognitoAuthConfig = {
-  authority: process.env.AUTHORITY,
-  client_id: process.env.CLIENT_ID,
-  redirect_uri: process.env.REDIRECT_URI,
-  response_type: process.env.OAUTH_REDIRECT_SIGN_RESPONSE_TYPE,
-  scope: process.env.SCOPE,
+  authority: getEnvVar('AUTHORITY'),
+  client_id: getEnvVar('CLIENT_ID'),
+  redirect_uri: getEnvVar('REDIRECT_URI'),
+  response_type: getEnvVar('OAUTH_REDIRECT_SIGN_RESPONSE_TYPE', 'code'),
+  scope: getEnvVar('SCOPE', 'email openid phone'),
+  // Add a flag for local mode
+  isLocalDev: !isEnvLocalLoaded(),
 };
 
 export default cognitoAuthConfig;

--- a/src/config/cognito-configure.js
+++ b/src/config/cognito-configure.js
@@ -1,8 +1,20 @@
 // src/config/cognito-config.js
 
 import cognitoAuthConfig from "./cognito-auth-config";
+import { isEnvLocalLoaded } from '../utils/env';
 
 export function configure() {
+  // If .env.local is missing, fallback to local dev mode and skip config
+  if (!isEnvLocalLoaded()) {
+    return {
+      ...cognitoAuthConfig,
+      // Optionally, set all sensitive/remote fields to undefined
+      authority: undefined,
+      client_id: undefined,
+      redirect_uri: undefined,
+      isLocalDev: true,
+    };
+  }
   // Assuming you have two redirect URIs, and the first is for localhost and
   // second is for production
   const [localRedirectURI, prodRedirectURI] =

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,35 @@
+// src/utils/env.js
+
+// This utility checks for required env vars and provides fallbacks for local dev
+
+const REQUIRED_ENV_VARS = [
+  'AUTHORITY',
+  'CLIENT_ID',
+  'REDIRECT_URI',
+  'OAUTH_REDIRECT_SIGN_RESPONSE_TYPE',
+  'SCOPE',
+  'REGION',
+  'USER_POOL_ID',
+  'USER_POOL_WEB_CLIENT_ID',
+  'OAUTH_DOMAIN',
+  'OAUTH_REDIRECT_SIGN_OUT',
+  'ENV',
+];
+
+function isEnvLocalLoaded() {
+  // If any required env var is missing, assume .env.local is not loaded
+  return REQUIRED_ENV_VARS.every((key) => typeof process.env[key] === 'string' && process.env[key] !== '');
+}
+
+function getEnvVar(key, fallback = undefined) {
+  if (typeof process.env[key] === 'string' && process.env[key] !== '') {
+    return process.env[key];
+  }
+  // Fallback for local dev
+  if (fallback !== undefined) return fallback;
+  // Some defaults for local dev
+  if (key === 'ENV') return 'localhost';
+  return undefined;
+}
+
+export { isEnvLocalLoaded, getEnvVar };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -11,9 +11,13 @@ import {
   LOGOUT_BUTTON,
   LOGOUT_PATH,
 } from "./constants";
+import { isEnvLocalLoaded } from './env';
 
 export function useNavbarItemsMobile() {
-  // const { route } = useAuthenticator((context) => [context.route]);
+  if (!isEnvLocalLoaded()) {
+    // If .env.local is missing, do not render auth-related navbar items
+    return useThemeConfig().navbar.items;
+  }
   const auth = useAuth();
 
   let authElement;
@@ -61,7 +65,10 @@ export function useNavbarItemsMobile() {
 }
 
 export function useNavbarItemsDesktop() {
-  // const { route } = useAuthenticator((context) => [context.route]);
+  if (!isEnvLocalLoaded()) {
+    // If .env.local is missing, do not render auth-related navbar items
+    return useThemeConfig().navbar.items;
+  }
   const auth = useAuth();
 
   let authElement;


### PR DESCRIPTION
## 📋 PR Info

### Description:
Refactored the code so that if no env file is provided, it assumes a local development environment and gracefully fails to render env value functionality. This is so quick edits can be made to the documentation without needing to touch the authentication related functionality. 

### Tested
Tested locally, needs to be tested with production env vars to ensure everything still works as before.